### PR TITLE
bugfix: caused error when solving merge conflicts, fixed here

### DIFF
--- a/App/Components/Chat/CompChatView.razor
+++ b/App/Components/Chat/CompChatView.razor
@@ -60,6 +60,10 @@
     
     protected override async Task OnParametersSetAsync()
     {
+        await using var db = await Db.CreateDbContextAsync();
+        Chat = await db.Chats.Include(i => i.Users)
+            .Include(i => i.Messages)
+            .FirstOrDefaultAsync(c => c.ID == ChatID);
         if (Chat is GroupChat groupChat)
         {
             ChatName = groupChat.Name;


### PR DESCRIPTION
oops
(context is that i removed a piece of code without reading quite well):
```
        await using var db = await Db.CreateDbContextAsync();
        Chat = await db.Chats.Include(i => i.Users)
            .Include(i => i.Messages)
            .FirstOrDefaultAsync(c => c.ID == ChatID);
```
who knew removing the thing that retrieves a necessary item would cause an intentional exception to be thrown smh