### PR TITLE
Explicit ChatUser Join Entity

### DIFF
--- a/App/Classes/AppDbContext/AppDbContext.cs
+++ b/App/Classes/AppDbContext/AppDbContext.cs
@@ -26,7 +26,16 @@ public class AppDbContext : IdentityDbContext<User, IdentityRole<int>, int>
             .WithMany(e => e.ModeratedChats);
         modelBuilder.Entity<User>()
             .HasMany(u => u.Chats)
-            .WithMany(c => c.Users);
+            .WithMany(c => c.Users)
+            .UsingEntity<ChatUser>(
+                l => l.HasOne<Chat>(e => e.Chat)
+                    .WithMany(e => e.ChatUsers)
+                    .HasForeignKey(e => e.ChatId),
+                r => r.HasOne<User>(e => e.User)
+                    .WithMany(e => e.UserChats)
+                    .HasForeignKey(e => e.UserId),
+                j => j.Property(e => e.LastAccess).HasDefaultValueSql("CURRENT_TIMESTAMP")
+            );
         modelBuilder.Entity<GroupChat>()
             .HasOne(h => h.Owner)
             .WithMany(w => w.OwnedChats);

--- a/App/Classes/AppDbContext/Chat.cs
+++ b/App/Classes/AppDbContext/Chat.cs
@@ -7,5 +7,5 @@ public class Chat
     [Key] public int ID { get; set; }
 
     public ICollection<User> Users { get; set; } = default!;
-    public ICollection<Message>? Messages { get; set; }
+    public ICollection<Message>? Messages { get; set; }public ICollection<ChatUser> ChatUsers { get; set; } = default!;
 }

--- a/App/Classes/AppDbContext/ChatUser.cs
+++ b/App/Classes/AppDbContext/ChatUser.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bamboozlers.Classes.AppDbContext;
+
+[PrimaryKey(nameof(UserId),nameof(ChatId))]
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+
+public class ChatUser
+{
+    public User User { get; set; } = default!;
+    public int UserId { get; set; }
+
+    public Chat Chat { get; set; } = default!;
+    public int ChatId { get; set; }
+    public DateTime LastAccess { get; set; }
+}

--- a/App/Classes/AppDbContext/User.cs
+++ b/App/Classes/AppDbContext/User.cs
@@ -14,6 +14,8 @@ public class User : IdentityUser<int>
     public ICollection<GroupChat> ModeratedChats { get; set; } = default!;
     public ICollection<GroupChat> OwnedChats { get; set; } = default!;
 
+    public ICollection<ChatUser> UserChats { get; set; } = default!;
+    
     public string GetName()
     {
         return DisplayName.IsNullOrEmpty() ? UserName! : DisplayName!;

--- a/App/Migrations/20240408014223_Initial.cs
+++ b/App/Migrations/20240408014223_Initial.cs
@@ -253,20 +253,21 @@ namespace Bamboozlers.Migrations
                 name: "ChatUser",
                 columns: table => new
                 {
-                    ChatsID = table.Column<int>(type: "int", nullable: false),
-                    UsersId = table.Column<int>(type: "int", nullable: false)
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    ChatId = table.Column<int>(type: "int", nullable: false),
+                    LastAccess = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_ChatUser", x => new { x.ChatsID, x.UsersId });
+                    table.PrimaryKey("PK_ChatUser", x => new { x.UserId, x.ChatId });
                     table.ForeignKey(
-                        name: "FK_ChatUser_AspNetUsers_UsersId",
-                        column: x => x.UsersId,
+                        name: "FK_ChatUser_AspNetUsers_UserId",
+                        column: x => x.UserId,
                         principalTable: "AspNetUsers",
                         principalColumn: "Id");
                     table.ForeignKey(
-                        name: "FK_ChatUser_Chats_ChatsID",
-                        column: x => x.ChatsID,
+                        name: "FK_ChatUser_Chats_ChatId",
+                        column: x => x.ChatId,
                         principalTable: "Chats",
                         principalColumn: "ID");
                 });
@@ -401,9 +402,9 @@ namespace Bamboozlers.Migrations
                 column: "OwnerID");
 
             migrationBuilder.CreateIndex(
-                name: "IX_ChatUser_UsersId",
+                name: "IX_ChatUser_ChatId",
                 table: "ChatUser",
-                column: "UsersId");
+                column: "ChatId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_FriendRequests_ReceiverID",

--- a/App/Migrations/AppDbContextModelSnapshot.cs
+++ b/App/Migrations/AppDbContextModelSnapshot.cs
@@ -59,6 +59,26 @@ namespace Bamboozlers.Migrations
                     b.UseTphMappingStrategy();
                 });
 
+            modelBuilder.Entity("Bamboozlers.Classes.AppDbContext.ChatUser", b =>
+                {
+                    b.Property<int>("UserId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ChatId")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime>("LastAccess")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.HasKey("UserId", "ChatId");
+
+                    b.HasIndex("ChatId");
+
+                    b.ToTable("ChatUser");
+                });
+
             modelBuilder.Entity("Bamboozlers.Classes.AppDbContext.FriendRequest", b =>
                 {
                     b.Property<int>("SenderID")
@@ -226,21 +246,6 @@ namespace Bamboozlers.Migrations
                         .HasFilter("[NormalizedUserName] IS NOT NULL");
 
                     b.ToTable("AspNetUsers", (string)null);
-                });
-
-            modelBuilder.Entity("ChatUser", b =>
-                {
-                    b.Property<int>("ChatsID")
-                        .HasColumnType("int");
-
-                    b.Property<int>("UsersId")
-                        .HasColumnType("int");
-
-                    b.HasKey("ChatsID", "UsersId");
-
-                    b.HasIndex("UsersId");
-
-                    b.ToTable("ChatUser");
                 });
 
             modelBuilder.Entity("GroupChatUser", b =>
@@ -428,6 +433,25 @@ namespace Bamboozlers.Migrations
                     b.Navigation("Blocker");
                 });
 
+            modelBuilder.Entity("Bamboozlers.Classes.AppDbContext.ChatUser", b =>
+                {
+                    b.HasOne("Bamboozlers.Classes.AppDbContext.Chat", "Chat")
+                        .WithMany("ChatUsers")
+                        .HasForeignKey("ChatId")
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .IsRequired();
+
+                    b.HasOne("Bamboozlers.Classes.AppDbContext.User", "User")
+                        .WithMany("UserChats")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .IsRequired();
+
+                    b.Navigation("Chat");
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("Bamboozlers.Classes.AppDbContext.FriendRequest", b =>
                 {
                     b.HasOne("Bamboozlers.Classes.AppDbContext.User", "Receiver")
@@ -512,21 +536,6 @@ namespace Bamboozlers.Migrations
                     b.Navigation("Sender");
                 });
 
-            modelBuilder.Entity("ChatUser", b =>
-                {
-                    b.HasOne("Bamboozlers.Classes.AppDbContext.Chat", null)
-                        .WithMany()
-                        .HasForeignKey("ChatsID")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
-
-                    b.HasOne("Bamboozlers.Classes.AppDbContext.User", null)
-                        .WithMany()
-                        .HasForeignKey("UsersId")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("GroupChatUser", b =>
                 {
                     b.HasOne("Bamboozlers.Classes.AppDbContext.GroupChat", null)
@@ -606,12 +615,16 @@ namespace Bamboozlers.Migrations
 
             modelBuilder.Entity("Bamboozlers.Classes.AppDbContext.Chat", b =>
                 {
+                    b.Navigation("ChatUsers");
+
                     b.Navigation("Messages");
                 });
 
             modelBuilder.Entity("Bamboozlers.Classes.AppDbContext.User", b =>
                 {
                     b.Navigation("OwnedChats");
+
+                    b.Navigation("UserChats");
                 });
 #pragma warning restore 612, 618
         }


### PR DESCRIPTION
do we want this?

explicitly defines the join entity/table used by EF, includes a payload datetime attribute for 'last access'

could be used for determining unread message counts and thus pseudo-notifications